### PR TITLE
Enhancement/hide tasks closed jobs

### DIFF
--- a/frontend/src/app/components/task-card.component.html
+++ b/frontend/src/app/components/task-card.component.html
@@ -1,7 +1,7 @@
 <div class="board-card d-flex flex-column pointer" *ngIf="task$ | async as task">
     <ng-container *ngIf="show_job_details">
         <p class="small muted d-flex align-items-center mb-1">
-            <span class="color-indicator" [style.backgroundColor]="task._job._client.colour"></span>
+            <span class="color-indicator" [style.backgroundColor]="task._job.colour"></span>
             {{ task | get:'_job._client.name' }} / {{ task | get:'_job.title' }}
         </p>
     </ng-container>

--- a/frontend/src/app/state/selectors/taskboard.ts
+++ b/frontend/src/app/state/selectors/taskboard.ts
@@ -32,7 +32,7 @@ export const getTasksForTaskBoardForUser = (user: number) => createSelector(
 )
 
 const getMappedTasksForUser = (tasks: ITask[], user: number, filters: IFilter, assignees: ITaskAssignee[]) => {
-    let objs = tasks;
+    let objs = _.filter(tasks, t => !t._job._status.closed);
     
     // only tasks assigned to user
     let ids = _.map(_.filter(assignees, ['user', user]), 'task');
@@ -52,7 +52,7 @@ const getMappedTasksForUser = (tasks: ITask[], user: number, filters: IFilter, a
 }
 
 const getMappedAssigneesForUser = (tasks: ITask[], user: number, filters: IFilter, assignees: ITaskAssignee[]) => {
-    let objs = tasks;
+    let objs = _.filter(tasks, t => !t._job._status.closed);
 
     // only tasks assigned to user
     let filteredAssignees = _.orderBy(_.filter(assignees, ['user', user]), ['board_order'], ['asc']);

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,7 +9,7 @@ django-reversion
 django-storages
 django-taggit
 django-taggit-serializer
-djangorestframework
+djangorestframework<3.11.0
 flatbuffers
 huey[backends]<2.0.0
 markdown


### PR DESCRIPTION
We recently had a case where tasks on a job were finished, but not reviewed or released. The job was unfortunately closed, however the tasks still remained visible to assignees.

This PR addresses this and filters out tasks from closed jobs, thereby cleaning up the task list and board. 

